### PR TITLE
Reverting changes from sync with github-config

### DIFF
--- a/.github/.syncignore
+++ b/.github/.syncignore
@@ -1,2 +1,5 @@
 CODEOWNERS
 dependabot.yml
+workflows/push-image.yml
+workflows/update-builder-toml.yml
+workflows/create-release.yml

--- a/.github/workflows/.syncignore
+++ b/.github/workflows/.syncignore
@@ -1,3 +1,0 @@
-push-image.yml
-update-builder-toml.yml
-create-release.yml

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Compare With Previous Release
       id: compare_previous_release
       run: |
-        if [ -z "$(git diff $(git describe --tags --abbrev=0) -- builder.toml)" ]
+        if [ -z "$(git diff $(git describe --tags --abbrev=0) -- builder-buildpackless.toml)" ]
         then
           echo "builder_changes=false" >> "$GITHUB_OUTPUT"
         else

--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -38,7 +38,7 @@ jobs:
 
     - name: Create Builder Image
       run: |
-        pack builder create builder --config builder.toml
+        pack builder create builder --config builder-buildpackless.toml
 
     - name: Push To Dockerhub
       env:

--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -30,33 +30,38 @@ jobs:
       with:
         pack-version: ${{ steps.pack-version.outputs.version }}
 
+    - name: Install crane
+      run: |
+        VERSION=$(curl -s "https://api.github.com/repos/google/go-containerregistry/releases/latest" | jq -r '.tag_name')
+        OS=Linux
+        ARCH=x86_64
+        curl -sL "https://github.com/google/go-containerregistry/releases/download/${VERSION}/go-containerregistry_${OS}_${ARCH}.tar.gz" > go-containerregistry.tar.gz
+
+        tar -zxvf go-containerregistry.tar.gz -C "${HOME}/bin" crane
+        chmod +x "${HOME}/bin/crane"
+
     - name: Enable Experimental Pack Features
       run: |
         if [ -f "scripts/options.json" ] && jq -e -r .pack_config_enable_experimental "scripts/options.json" > /dev/null; then
           pack config experimental true
         fi
 
-    - name: Create Builder Image
-      run: |
-        pack builder create builder --config builder-buildpackless.toml
+    - name: Create Builder Image and Push To Dockerhub
 
-    - name: Push To Dockerhub
       env:
         PAKETO_BUILDPACKS_DOCKERHUB_USERNAME: ${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_USERNAME }}
         PAKETO_BUILDPACKS_DOCKERHUB_PASSWORD: ${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_PASSWORD }}
         GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
       run: |
         DOCKERHUB_ORG="${GITHUB_REPOSITORY_OWNER/-/}" # translates 'paketo-buildpacks' to 'paketobuildpacks'
-        # Strip off the Github org prefix from repo name
-        # paketo-buildpacks/builder-with-some-name --> builder-with-some-name
-        registry_repo=$(echo "${{ github.repository }}" | sed 's/^.*\///')
+        registry_repo="ubuntu-noble-builder-buildpackless"
 
         echo "${PAKETO_BUILDPACKS_DOCKERHUB_PASSWORD}" | docker login --username "${PAKETO_BUILDPACKS_DOCKERHUB_USERNAME}" --password-stdin
-        docker tag builder "${DOCKERHUB_ORG}/${registry_repo}:latest"
-        docker tag builder "${DOCKERHUB_ORG}/${registry_repo}:${{ steps.event.outputs.tag }}"
 
-        docker push "${DOCKERHUB_ORG}/${registry_repo}:latest"
-        docker push "${DOCKERHUB_ORG}/${registry_repo}:${{ steps.event.outputs.tag }}"
+        # In order to publish multi-arch builders with pack, the builder MUST be published.
+        # It cannot be created locally and then pushed
+        pack builder create "${DOCKERHUB_ORG}/${registry_repo}:${{ steps.event.outputs.tag }}" --config builder-buildpackless.toml --publish
+        crane copy "${DOCKERHUB_ORG}/${registry_repo}:${{ steps.event.outputs.tag }}" "${DOCKERHUB_ORG}/${registry_repo}:latest"
 
   failure:
     name: Alert on Failure

--- a/.github/workflows/update-builder-toml.yml
+++ b/.github/workflows/update-builder-toml.yml
@@ -24,13 +24,14 @@ jobs:
       uses: paketo-buildpacks/github-config/actions/builder/update@main
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
+        filename: "builder-buildpackless.toml"
 
     - name: Git commit
       id: commit
       uses: paketo-buildpacks/github-config/actions/pull-request/create-commit@main
       with:
         message: "Update builder.toml"
-        pathspec: "builder.toml"
+        pathspec: "builder-buildpackless.toml"
         keyid: ${{ secrets.PAKETO_BOT_GPG_SIGNING_KEY_ID }}
         key: ${{ secrets.PAKETO_BOT_GPG_SIGNING_KEY }}
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR reverts the changes from github-config sync PR https://github.com/paketo-buildpacks/ubuntu-noble-builder/pull/41. It also properly excludes the files from not syncing again.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
